### PR TITLE
Fixed broken "PUBLICATIONS on DBLP" link.

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -2,25 +2,27 @@
   people:
   - name: Mike Franklin
     url: http://www.cs.berkeley.edu/~franklin/
-    dblp: michael_j_franklin
+    dblp: Michael_J._Franklin
   - name: Joe Hellerstein
     url: http://db.cs.berkeley.edu/jmh/
-    dblp: joseph_m_hellerstein
+    dblp: Joseph_M._Hellerstein
   - name: Ion Stoica
     url: http://www.cs.berkeley.edu/~istoica/
   - name: Joseph Gonzalez
     url: http://www.cs.berkeley.edu/~jegonzal/
-    dblp: joseph_e_gonzalez
   - name: Ali Ghodsi
     url: http://www.cs.berkeley.edu/~alig/
   - name: Eric Brewer
     url: https://www.cs.berkeley.edu/~brewer/
+    dblp: Eric_A._Brewer
   - name: Raluca Ada Popa
     url: http://www.eecs.berkeley.edu/~raluca/
+    dblp: Raluca_A._Popa
 - description: collaborators and postdocs
   people:
   - name: Rachit Agarwal
     url: http://www.cs.berkeley.edu/~rachit/
+    dblp: Rachit_Agarwal_0001
   - name: Zhao Zhang
     url: http://www.eecs.berkeley.edu/~zhaozhang/
     dblp: _ # returns too many unrelated results
@@ -44,6 +46,7 @@
     url: https://github.com/nicklan
   - name: Evan Sparks
     url: http://etrain.github.io/about.html
+    dblp: Evan_R._Sparks
   - name: Liwen Sun
     url: http://scholar.google.com/citations?user=Phf6aX0AAAAJ&hl=en
   - name: Shivaram Venkataraman
@@ -52,12 +55,12 @@
     url: https://johann.schleier-smith.com/
   - name: Chenggang Wu
     url: https://cs.brown.edu/~cw75/
-    dblp: _
+    dblp: _ # Chenggang_Wu is a different Chenggang Wu
   - name: Yifan Wu
     url: http://yifanwu.net/
-    dblp: _
+    dblp: _ # Yifan_Wu is a different Yifan Wu
   - name: Xin Wang
-    dblp: _
+    dblp: _ # No author entry for Xin Wang
   - name: Vikram Sreekanti
     url: http://www.vikrams.io/
   - name: Michael Whittaker
@@ -84,6 +87,7 @@
     url: https://www.linkedin.com/in/jshrsn
   - name: Ameet Talkwalkar
     url: http://web.cs.ucla.edu/~ameet/
+    dblp: _ # No author entry for Ameet Talkwalkar
   - name: Beth Trushkowsky
     url: https://www.cs.hmc.edu/~beth//
   - name: Reynold Xin
@@ -94,6 +98,6 @@
     url: http://www.cs.berkeley.edu/~jnwang/
   - name: Erik Krogen
     url: https://www.linkedin.com/in/erik-krogen-42814250
-    dblp: _
+    dblp: Erik_T._Krogen
   - name: Tomer Kaftan
     url: https://www.linkedin.com/in/tomerkaftan

--- a/index.html
+++ b/index.html
@@ -28,8 +28,15 @@ computing and interaction, and technology for developing regions.</div>
 </ul>
 {% endfor %}
 
-{% capture dblp_authors %}{% for group in site.data.people %}{% for person in group.people %}author:{% if person.dblp %}{{ person.dblp }}{% else %}{{ person.name | replace:' ','_' | replace:'-','_') | downcase }}{% endif %}|{% endfor %}{% endfor %}{% endcapture %}
-<h2 style="margin-top:0.5em; margin-bottom:.5em;"><a style="float: left;" href="http://dblp.org/search/index.php#query={{ dblp_authors }}">PUBLICATIONS <span class="boldtext">on
+<!--
+Note that this code is placed on a single line in order to avoid Jekyll from
+inserting a lot of unwanted whitespace into dblp_authors. Googling around, it
+seems like there isn't a nice alternative to this.
+-->
+{% capture dblp_authors %}
+{% for group in site.data.people %}{% for person in group.people %}author:{% if person.dblp %}{{ person.dblp }}{% else %}{{ person.name | replace:' ','_' }}{% endif %}:|{% endfor %}{% endfor %}
+{% endcapture %}
+<h2 style="margin-top:0.5em; margin-bottom:.5em;"><a style="float: left;" href="http://dblp.org/search/publ?q={{ dblp_authors }}">PUBLICATIONS <span class="boldtext">on
       DBLP</span></a> <a style="float:right;" href="seminar"><span class="boldtext">RECENT</span> GROUP READINGS</a></h2><br>
 
 <div id="logobox">


### PR DESCRIPTION
This is [the old "PUBLICATIONS on DBLP" link address][old_link] on the [db.cs.berkeley.edu][dbsite] website:

```
http://dblp.org/search/index.php#query=author:michael_j_franklin|author:joseph_m_hellerstein|author:ion_stoica|author:joseph_e_gonzalez|author:ali_ghodsi|author:eric_brewer|author:raluca_ada_popa|author:rachit_agarwal|author:_|author:_|author:julian_shun|author:sara_alspaugh|author:daniel_crankshaw|author:daniel_haas|author:sanjay_krishnan|author:nick_lanham|author:evan_sparks|author:liwen_sun|author:shivaram_venkataraman|author:johann_schleier_smith|author:_|author:_|author:_|author:vikram_sreekanti|author:michael_whittaker|author:larry_xu|author:peter_alvaro|author:sameer_agarwal|author:peter_bailis|author:daniel_bruckner|author:neil_conway|author:tim_kraska|author:gene_pang|author:josh_rosen|author:ameet_talkwalkar|author:beth_trushkowsky|author:reynold_xin|author:christos_kozanitis|author:jiannan_wang|author:_|author:tomer_kaftan|
```

Clicking on the link takes you to dblp with the search field filled in, but you are met with a sobering *no matches* result.

First, I went to [Michael Franklin's dblp page][franklin]. Next to the "Michael J. Franklin" text at the top is a "little magnifying glass with rightward arrow" icon. Mousing over that icon produced a drop-down menu with the last entry being a link to [view the author in dblp search][franklin_search]. Clicking on this link brings you to the first of the following two equivalent URLs:

```
http://dblp.dagstuhl.de/search/publ?q=author:Michael_J._Franklin:
http://dblp.org/search/publ?q=author:Michael_J._Franklin:
```

The following URLs bring you somewhere else:

- `http://dblp.org/search/publ?q=author:Michael_J._Franklin` (missing second colon) returns more search results.
- `http://dblp.org/search/publ?q=author:michael_J._Franklin:` (lowercase m) returns *no matches*
- `http://dblp.org/search/publ?q=author:Michael_J_Franklin:` (missing period after J) returns *no matches*

From this tinkering, it seems like dblp is somewhat particular about capitalization and punctuation. Let's take the old link, add colons to the end of each author, change the `index.php#query=` bit to `publ?q=`, and correct the capitalization and punctuation of Michael Franklin. Here's [what we get](http://bit.ly/2lBUinh):

```
http://dblp.org/search/publ?q=author:Michael_J._Franklin:|author:joseph_m_hellerstein:|author:ion_stoica:|author:joseph_e_gonzalez:|author:ali_ghodsi:|author:eric_brewer:|author:raluca_ada_popa:|author:rachit_agarwal:|author:_:|author:_:|author:julian_shun:|author:sara_alspaugh:|author:daniel_crankshaw:|author:daniel_haas:|author:sanjay_krishnan:|author:nick_lanham:|author:evan_sparks:|author:liwen_sun:|author:shivaram_venkataraman:|author:johann_schleier_smith:|author:_:|author:_:|author:_:|author:vikram_sreekanti:|author:michael_whittaker:|author:larry_xu:|author:peter_alvaro:|author:sameer_agarwal:|author:peter_bailis:|author:daniel_bruckner:|author:neil_conway:|author:tim_kraska:|author:gene_pang:|author:josh_rosen:|author:ameet_talkwalkar:|author:beth_trushkowsky:|author:reynold_xin:|author:christos_kozanitis:|author:jiannan_wang:|author:_:|author:tomer_kaftan:
```

Follow this link and you'll see we get results for Michael Franklin!

This PR changes `index.html` and `_data/people.yml` to make sure the produced dblp link is in the correct form.

[old_link]:        http://bit.ly/2kfJGya
[dbsite]:          http://db.cs.berkeley.edu/
[franklin]:        http://dblp.dagstuhl.de/pers/hd/f/Franklin:Michael_J=
[franklin_search]: http://dblp.dagstuhl.de/search/publ?q=author:Michael_J._Franklin:
[franklin_fixed]:  http://bit.ly/2lBUinh